### PR TITLE
Add scoped grants for supporter early downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 - One-click **➕ Download** on Arc en Ciel model cards.
 - **Model-aware routing** for checkpoints, LoRAs, VAEs, and embeddings.
 - Background worker with retry back-off, disk-space guard, SHA-256 verification, and live console logs.
+- Supporter Early Access downloads use short-lived, job-scoped grants that are never placed in URLs.
+- This release advertises `link_download_grant_v1`; older clients keep receiving public jobs but cannot claim private pre-release jobs.
 - Remote worker control from the ArcEnCiel Link panel (website) through the local bridge endpoint.
 - Hourly inventory sync so duplicates are skipped when hashes already exist locally.
 - Optional sidecars next to downloaded models (`.preview.png`, `.arcenciel.info`, optional `.html`).
@@ -66,6 +68,7 @@ pip install -r arcenciel-link-webui/requirements.txt
 ## 🛡️ Credentials and security
 
 - **Link Key (`lk_...`) is the primary credential** for current ArcEnCiel worker websocket auth.
+- Early Access grants are received only by the worker, sent in a dedicated request header, and rejected on redirects so they cannot leak to another download host.
 - API key fields remain for legacy/self-hosted compatibility, but Link Keys are recommended for all active setups.
 - At startup, existing credentials are migrated into the OS keyring (`keyring` package) when available.
 - If no keyring backend exists, secrets remain in `arcenciel_link/config.json`.

--- a/arcenciel_link/client.py
+++ b/arcenciel_link/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64, json, queue, threading, time, websocket, re
 from .config import load, save
 from .utils import list_subfolders, get_http_session
@@ -212,7 +214,13 @@ def _send_ws_payload(payload: dict, *, default_type: str | None = None):
 def _send_worker_state(running: bool | None = None):
     if running is None:
         running = _is_worker_running()
-    _send_ws_payload({"type": "worker_state", "running": bool(running)})
+    _send_ws_payload(
+        {
+            "type": "worker_state",
+            "running": bool(running),
+            "capabilities": ["link_download_grant_v1"],
+        }
+    )
 
 
 def _send_control_ack(payload: dict):

--- a/arcenciel_link/downloader.py
+++ b/arcenciel_link/downloader.py
@@ -88,10 +88,51 @@ def _sync_inventory(hashes: list[str]) -> None:
     push_inventory(hashes)
 
 
-def _download_with_retry(url: str, tmp: Path, progress_cb):
+_LINK_GRANT_HEADER = "X-ArcEnCiel-Link-Grant"
+_LINK_GRANT_PATH = re.compile(r"^/api/link/queue/\d+/download(?:/|$)")
+
+
+def _grant_headers_for_job(job: dict, download_url: str) -> dict[str, str] | None:
+    raw_grant = job.get("downloadGrant")
+    if raw_grant is None:
+        return None
+    if not isinstance(raw_grant, str) or not raw_grant.strip() or len(raw_grant) > 4096:
+        raise RuntimeError("Invalid Link download grant")
+
+    parsed = urlparse(download_url)
+    hostname = (parsed.hostname or "").lower()
+    official_host = hostname == "arcenciel.io" or hostname.endswith(".arcenciel.io")
+    local_dev_host = bool(_cfg.get("_dev_mode")) and hostname in {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+    }
+    secure_transport = parsed.scheme == "https" or (
+        local_dev_host and parsed.scheme == "http"
+    )
+    if not (official_host or local_dev_host) or not secure_transport:
+        raise RuntimeError("Link download grant URL is not trusted")
+    if not _LINK_GRANT_PATH.match(parsed.path):
+        raise RuntimeError("Link download grant URL has an invalid path")
+
+    return {_LINK_GRANT_HEADER: raw_grant.strip()}
+
+
+def _download_with_retry(
+    url: str,
+    tmp: Path,
+    progress_cb,
+    *,
+    request_headers: dict[str, str] | None = None,
+):
     for attempt in range(1, MAX_RETRIES + 1):
         try:
-            download_file(url, tmp, progress_cb)
+            download_file(
+                url,
+                tmp,
+                progress_cb,
+                request_headers=request_headers,
+            )
             return
         except Exception as e:
             tmp.unlink(missing_ok=True)
@@ -230,6 +271,7 @@ def _worker():
             if not url_raw:
                 raise RuntimeError("No download URL provided by server")
 
+            grant_headers = _grant_headers_for_job(job, url_raw)
             url_path  = unquote(urlparse(url_raw).path)
 
             sha_server = ver.get("sha256")
@@ -280,7 +322,12 @@ def _worker():
                 report_progress(job["id"], progress=pct)
                 _print_progress(label, pct)
 
-            _download_with_retry(url_raw, tmp_path, _progress_cb)
+            _download_with_retry(
+                url_raw,
+                tmp_path,
+                _progress_cb,
+                request_headers=grant_headers,
+            )
 
             # hash
             sha_local = sha256_of_file(tmp_path)
@@ -424,4 +471,3 @@ def generate_sidecars_for_existing():
         _write_info_json(meta, h, preview, dst_path)
         if _cfg.get("save_html_preview"):
             _write_html(meta | {"sha256": h}, preview, dst_path)
-

--- a/arcenciel_link/utils.py
+++ b/arcenciel_link/utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import hashlib, json, os, glob
 from pathlib import Path
 from typing import List, Dict, Generator, Set
@@ -33,9 +34,21 @@ def get_http_session() -> requests.Session:
 log = logging.getLogger("arcenciel_link")
 log.setLevel(logging.INFO)
 
-def download_file(url: str, dst: Path, progress_cb):
+def download_file(
+    url: str,
+    dst: Path,
+    progress_cb,
+    *,
+    request_headers: Dict[str, str] | None = None,
+):
     session = get_http_session()
-    with session.get(url, stream=True, timeout=60) as r:
+    with session.get(
+        url,
+        stream=True,
+        timeout=60,
+        headers=request_headers,
+        allow_redirects=request_headers is None,
+    ) as r:
         r.raise_for_status()
         total = int(r.headers.get("content-length", 0))
         chunk = 1024 * 1024

--- a/tests/test_link_download_grant.py
+++ b/tests/test_link_download_grant.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_utils_module():
+    spec = importlib.util.spec_from_file_location(
+        "arcenciel_link_utils_for_test",
+        REPO_ROOT / "arcenciel_link" / "utils.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_downloader_module(monkeypatch: pytest.MonkeyPatch):
+    package = types.ModuleType("arcenciel_link")
+    package.__path__ = [str(REPO_ROOT / "arcenciel_link")]
+    monkeypatch.setitem(sys.modules, "arcenciel_link", package)
+
+    config = types.ModuleType("arcenciel_link.config")
+    config.load = lambda: {
+        "_dev_mode": False,
+        "min_free_mb": 2048,
+        "max_retries": 1,
+        "backoff_base": 1,
+    }
+    monkeypatch.setitem(sys.modules, "arcenciel_link.config", config)
+
+    client = types.ModuleType("arcenciel_link.client")
+    client.BASE_URL = "https://link.arcenciel.io/api/link"
+    client.queue_next_job = Mock()
+    client.report_progress = Mock()
+    client.push_inventory = Mock()
+    client._sock = Mock()
+    client._open_evt = Mock()
+    client.headers = Mock(return_value={})
+    monkeypatch.setitem(sys.modules, "arcenciel_link.client", client)
+
+    utils = types.ModuleType("arcenciel_link.utils")
+    utils.download_file = Mock()
+    utils.sha256_of_file = Mock()
+    utils.get_model_path = Mock()
+    utils.list_model_hashes = Mock()
+    utils.update_cached_hash = Mock()
+    utils.get_http_session = Mock(return_value=Mock())
+    monkeypatch.setitem(sys.modules, "arcenciel_link.utils", utils)
+
+    spec = importlib.util.spec_from_file_location(
+        "arcenciel_link.downloader",
+        REPO_ROOT / "arcenciel_link" / "downloader.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "arcenciel_link.downloader", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_client_module(monkeypatch: pytest.MonkeyPatch):
+    package = types.ModuleType("arcenciel_link")
+    package.__path__ = [str(REPO_ROOT / "arcenciel_link")]
+    monkeypatch.setitem(sys.modules, "arcenciel_link", package)
+
+    config = types.ModuleType("arcenciel_link.config")
+    config.load = lambda: {
+        "_dev_mode": False,
+        "base_url": "https://link.arcenciel.io/api/link",
+        "link_key": "",
+        "api_key": "",
+    }
+    config.save = Mock()
+    monkeypatch.setitem(sys.modules, "arcenciel_link.config", config)
+
+    utils = types.ModuleType("arcenciel_link.utils")
+    utils.list_subfolders = Mock()
+    utils.get_http_session = Mock(return_value=Mock())
+    monkeypatch.setitem(sys.modules, "arcenciel_link.utils", utils)
+
+    websocket = types.ModuleType("websocket")
+    websocket.WebSocketApp = Mock()
+    monkeypatch.setitem(sys.modules, "websocket", websocket)
+
+    import signal
+
+    monkeypatch.setattr(signal, "signal", Mock())
+    spec = importlib.util.spec_from_file_location(
+        "arcenciel_link.client",
+        REPO_ROOT / "arcenciel_link" / "client.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "arcenciel_link.client", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_download_file_sends_grant_header_without_following_redirects(tmp_path):
+    module = load_utils_module()
+    response = Mock()
+    response.headers = {"content-length": "4"}
+    response.iter_content.return_value = [b"data"]
+    response.__enter__ = Mock(return_value=response)
+    response.__exit__ = Mock(return_value=False)
+    session = Mock()
+    session.get.return_value = response
+    module._SESSION = session
+
+    destination = tmp_path / "model.part"
+    module.download_file(
+        "https://arcenciel.io/api/link/queue/7/download/model.safetensors",
+        destination,
+        Mock(),
+        request_headers={"X-ArcEnCiel-Link-Grant": "secret-token"},
+    )
+
+    session.get.assert_called_once_with(
+        "https://arcenciel.io/api/link/queue/7/download/model.safetensors",
+        stream=True,
+        timeout=60,
+        headers={"X-ArcEnCiel-Link-Grant": "secret-token"},
+        allow_redirects=False,
+    )
+    assert destination.read_bytes() == b"data"
+
+
+def test_regular_downloads_keep_redirect_support(tmp_path):
+    module = load_utils_module()
+    response = Mock()
+    response.headers = {}
+    response.iter_content.return_value = [b"data"]
+    response.__enter__ = Mock(return_value=response)
+    response.__exit__ = Mock(return_value=False)
+    session = Mock()
+    session.get.return_value = response
+    module._SESSION = session
+
+    module.download_file(
+        "https://cdn.example.com/model.safetensors",
+        tmp_path / "model.part",
+        Mock(),
+    )
+
+    assert session.get.call_args.kwargs["headers"] is None
+    assert session.get.call_args.kwargs["allow_redirects"] is True
+
+
+def test_worker_announces_download_grant_capability(monkeypatch):
+    module = load_client_module(monkeypatch)
+    module._sock = Mock()
+    module._open_evt.set()
+
+    module._send_worker_state(True)
+
+    payload = module.json.loads(module._sock.send.call_args.args[0])
+    assert payload == {
+        "type": "worker_state",
+        "running": True,
+        "capabilities": ["link_download_grant_v1"],
+    }
+
+
+def test_grant_is_only_sent_to_the_scoped_arcenciel_route(monkeypatch):
+    module = load_downloader_module(monkeypatch)
+    job = {"downloadGrant": "token"}
+
+    assert module._grant_headers_for_job(
+        job,
+        "https://arcenciel.io/api/link/queue/7/download/model.safetensors",
+    ) == {"X-ArcEnCiel-Link-Grant": "token"}
+
+    with pytest.raises(RuntimeError, match="not trusted"):
+        module._grant_headers_for_job(
+            job,
+            "https://evil.example/api/link/queue/7/download/model.safetensors",
+        )
+    with pytest.raises(RuntimeError, match="invalid path"):
+        module._grant_headers_for_job(
+            job,
+            "https://arcenciel.io/api/models/1/versions/2/download",
+        )
+    with pytest.raises(RuntimeError, match="Invalid Link download grant"):
+        module._grant_headers_for_job(
+            {"downloadGrant": ""},
+            "https://arcenciel.io/api/link/queue/7/download/model.safetensors",
+        )
+
+
+def test_retry_passes_grant_header_to_download_helper(monkeypatch, tmp_path):
+    module = load_downloader_module(monkeypatch)
+    callback = Mock()
+    headers = {"X-ArcEnCiel-Link-Grant": "token"}
+    target = tmp_path / "model.part"
+
+    module._download_with_retry(
+        "https://arcenciel.io/api/link/queue/7/download/model.safetensors",
+        target,
+        callback,
+        request_headers=headers,
+    )
+
+    module.download_file.assert_called_once_with(
+        "https://arcenciel.io/api/link/queue/7/download/model.safetensors",
+        target,
+        callback,
+        request_headers=headers,
+    )


### PR DESCRIPTION
## Summary
- announce the `link_download_grant_v1` worker capability
- accept short-lived early-download grants only on trusted Arc en Ciel job routes
- send grants in a dedicated header and disable redirects for grant-bearing requests
- document the security behavior

## Verification
- `python -m pytest tests` (5 passed)
- `ruff check tests/test_link_download_grant.py`
- `ruff format --check tests/test_link_download_grant.py`
- `git diff --check`

The modified legacy Python modules retain their existing Ruff baseline; the new test is clean.